### PR TITLE
added the line gem 'jekyll-include-cache' in the Gemfile in order to …

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 #gemspec
 gem "github-pages", group: :jekyll_plugins
+gem 'jekyll-include-cache'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,6 +120,8 @@ GEM
     jekyll-github-metadata (2.13.0)
       jekyll (>= 3.4, < 5.0)
       octokit (~> 4.0, != 4.4.0)
+    jekyll-include-cache (0.2.0)
+      jekyll (>= 3.7, < 5.0)
     jekyll-mentions (1.5.1)
       html-pipeline (~> 2.3)
       jekyll (>= 3.7, < 5.0)
@@ -243,6 +245,7 @@ PLATFORMS
 
 DEPENDENCIES
   github-pages
+  jekyll-include-cache
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
I added the line `gem 'jekyll-include-cache'` in the Gemfile in order to launch the website *locally* without an error

I wanted to be able to launch the website locally with the line command `bundle exec jekyll serve --watch` and that line needed to be added. Do you launch the website locally to visualize your changes or do you push it directly to GitHub? I had installed *bundle* and *jekyll* so it almost worked like a charm for me.
